### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/frontend/src/routes/items/_components/Create.svelte
+++ b/frontend/src/routes/items/_components/Create.svelte
@@ -4,7 +4,7 @@
 
   export let showModal = false;
   const dispatcher = createEventDispatcher();
-  let name, pic = 'https://source.unsplash.com/random', desc = '';
+  let name, pic = 'https://picsum.photos/600/400', desc = '';
 
 </script>
 <Modal bind:open={showModal}>


### PR DESCRIPTION
`frontend/src/routes/items/_components/Create.svelte` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns HTTP 503 instead of an image. Browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600?office | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Replaces the deprecated default `pic` URL in the Create-item form so the form preview renders a real placeholder again.

#### Replacement details

Picks 600×400 as a safe default size for the create-item preview slot. Picsum has no auth and no API key.

#### Background

I'm tracking the deprecated `source.unsplash.com/random` endpoint across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. But if you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
